### PR TITLE
update parameterValues attributes to use arrays instead of strings

### DIFF
--- a/src/main/java/gov/usgs/aqcu/model/report/SavedReportConfiguration.java
+++ b/src/main/java/gov/usgs/aqcu/model/report/SavedReportConfiguration.java
@@ -1,5 +1,6 @@
 package gov.usgs.aqcu.model.report;
 
+import java.util.List;
 import java.util.Map;
 
 import javax.validation.constraints.NotBlank;
@@ -21,7 +22,7 @@ public class SavedReportConfiguration {
 	private String primaryParameter;
 
 	@NotEmpty
-	private Map<String, String> parameterValues;
+	private Map<String, List<String>> parameterValues;
 
 	public String getReportName() {
 		return reportName;
@@ -43,11 +44,11 @@ public class SavedReportConfiguration {
 		this.primaryParameter = primaryParameter;
 	}
 
-	public Map<String, String> getParameterValues() {
+	public Map<String, List<String>> getParameterValues() {
 		return parameterValues;
 	}
 
-	public void setParameterValues(Map<String, String> parameterValues) {
+	public void setParameterValues(Map<String, List<String>> parameterValues) {
 		this.parameterValues = parameterValues;
 	}
 

--- a/src/test/java/gov/usgs/aqcu/controller/ConfigControllerMVCTest.java
+++ b/src/test/java/gov/usgs/aqcu/controller/ConfigControllerMVCTest.java
@@ -19,6 +19,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 
 import com.amazonaws.services.s3.model.AmazonS3Exception;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -369,8 +370,10 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void getFolderTest() throws Exception {
-        HashMap<String, String> testParams = new HashMap<>();
-        testParams.put("param1", "value1");
+        HashMap<String, String> testDefaults = new HashMap<>();
+        HashMap<String, List<String>> testParams = new HashMap<>();
+        testParams.put("test_param", Arrays.asList("test_param_value"));
+        testDefaults.put("param1", "value1");
         SavedReportConfiguration testReport = new SavedReportConfiguration();
         testReport.setCreatedUser("user1");
         testReport.setId("report1");
@@ -380,13 +383,13 @@ public class ConfigControllerMVCTest {
         testReport.setReportType("type1");
         testReport.setParameterValues(testParams);
         ReportsConfig testConfig = new ReportsConfig();
-        testConfig.setParameterDefaults(testParams);
+        testConfig.setParameterDefaults(testDefaults);
         testConfig.saveReport(testReport);
         FolderData testData = new FolderData();
         testData.setReports(testConfig.getSavedReportsList());
         testData.setFolders(Arrays.asList("folder1", "folder2"));
         testData.setGroupName("test");
-        testData.setParameterDefaults(testParams);
+        testData.setParameterDefaults(testDefaults);
         testData.setCurrentPath("test");
 
         given(reportConfigsService.getFolderData("test", "test")).willReturn(testData);
@@ -402,7 +405,7 @@ public class ConfigControllerMVCTest {
             .andExpect(jsonPath("$.reports[0].lastModifiedUser", is("user1")))
             .andExpect(jsonPath("$.reports[0].primaryParameter", is("param1")))
             .andExpect(jsonPath("$.reports[0].reportType", is("type1")))
-            .andExpect(jsonPath("$.reports[0].parameterValues.param1", is("value1")))
+            .andExpect(jsonPath("$.reports[0].parameterValues.test_param", is(Arrays.asList("test_param_value"))))
             .andExpect(jsonPath("$.folders", hasItems("folder1", "folder2")))
             .andExpect(jsonPath("$.parameterDefaults.param1", is("value1")));
     }
@@ -616,8 +619,8 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void createReportTest() throws Exception {
-        HashMap<String, String> goodParams = new HashMap<>();
-        goodParams.put("locationIdentifier", "test");
+        HashMap<String, List<String>> goodParams = new HashMap<>();
+        goodParams.put("locationIdentifier", Arrays.asList("test"));
         SavedReportConfiguration goodConfig = new SavedReportConfiguration();
         goodConfig.setParameterValues(goodParams);
         goodConfig.setPrimaryParameter("params");
@@ -635,8 +638,8 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void createReportValidationTest() throws Exception {
-        HashMap<String, String> testParams = new HashMap<>();
-        testParams.put("locationIdentifier", "test");
+        HashMap<String, List<String>> testParams = new HashMap<>();
+        testParams.put("locationIdentifier", Arrays.asList("test"));
         SavedReportConfiguration testConfig = new SavedReportConfiguration();
         testConfig.setParameterValues(testParams);
         testConfig.setPrimaryParameter("params");
@@ -796,8 +799,8 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void createReportErrorTest() throws Exception {
-        HashMap<String, String> testParams = new HashMap<>();
-        testParams.put("locationIdentifier", "test");
+        HashMap<String, List<String>> testParams = new HashMap<>();
+        testParams.put("locationIdentifier", Arrays.asList("test"));
         SavedReportConfiguration testConfig = new SavedReportConfiguration();
         testConfig.setParameterValues(testParams);
         testConfig.setPrimaryParameter("params");
@@ -847,8 +850,8 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void updateReportTest() throws Exception {
-        HashMap<String, String> goodParams = new HashMap<>();
-        goodParams.put("locationIdentifier", "test");
+        HashMap<String, List<String>> goodParams = new HashMap<>();
+        goodParams.put("locationIdentifier", Arrays.asList("test"));
         SavedReportConfiguration goodConfig = new SavedReportConfiguration();
         goodConfig.setParameterValues(goodParams);
         goodConfig.setPrimaryParameter("params");
@@ -867,8 +870,8 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void updateReportValidationTest() throws Exception {
-        HashMap<String, String> testParams = new HashMap<>();
-        testParams.put("locationIdentifier", "test");
+        HashMap<String, List<String>> testParams = new HashMap<>();
+        testParams.put("locationIdentifier", Arrays.asList("test"));
         SavedReportConfiguration testConfig = new SavedReportConfiguration();
         testConfig.setParameterValues(testParams);
         testConfig.setPrimaryParameter("params");
@@ -1054,8 +1057,8 @@ public class ConfigControllerMVCTest {
 
     @Test
     public void updateReportErrorTest() throws Exception {
-        HashMap<String, String> testParams = new HashMap<>();
-        testParams.put("locationIdentifier", "test");
+        HashMap<String, List<String>> testParams = new HashMap<>();
+        testParams.put("locationIdentifier", Arrays.asList("test"));
         SavedReportConfiguration testConfig = new SavedReportConfiguration();
         testConfig.setParameterValues(testParams);
         testConfig.setPrimaryParameter("params");

--- a/src/test/java/gov/usgs/aqcu/controller/ConfigControllerTest.java
+++ b/src/test/java/gov/usgs/aqcu/controller/ConfigControllerTest.java
@@ -210,12 +210,14 @@ public class ConfigControllerTest {
     @Test
     public void getFolderTest() throws Exception {
         HashMap<String, String> defaults = new HashMap<>();
+        HashMap<String, List<String>> params = new HashMap<>();
+        params.put("test_param", Arrays.asList("test_param_value"));
         defaults.put("test_key", "test_value");
         SavedReportConfiguration testReport = new SavedReportConfiguration();
         testReport.setCreatedUser("test_user");
         testReport.setId("test_id");
         testReport.setLastModifiedUser("test_user");
-        testReport.setParameterValues(defaults);
+        testReport.setParameterValues(params);
         testReport.setReportName("test_report");
         testReport.setReportType("test_type");
         FolderData folder1Data = new FolderData();

--- a/src/test/java/gov/usgs/aqcu/report/ReportConfigsServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/report/ReportConfigsServiceTest.java
@@ -149,12 +149,13 @@ public class ReportConfigsServiceTest {
     @Test
     public void getFolderDataBasicTest() throws Exception {
         HashMap<String, String> basicDefaults = new HashMap<>();
+        HashMap<String, List<String>> basicParams = new HashMap<>();
         basicDefaults.put("test_key", "test_value");
         SavedReportConfiguration basicReport = new SavedReportConfiguration();
         basicReport.setCreatedUser("test_user");
         basicReport.setId("test_report");
         basicReport.setLastModifiedUser("test_user");
-        basicReport.setParameterValues(basicDefaults);
+        basicReport.setParameterValues(basicParams);
         basicReport.setReportName("test_name");
         basicReport.setReportType("test_type");
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();
@@ -351,20 +352,22 @@ public class ReportConfigsServiceTest {
 
     @Test
     public void saveReportBasicTest() throws Exception {
-        HashMap<String, String> basicDefaults = new HashMap<>();
+    	HashMap<String, String> basicDefaults = new HashMap<>();
+        HashMap<String, List<String>> basicParams = new HashMap<>();
         basicDefaults.put("test_key", "test_value");
+        basicParams.put("test_param", Arrays.asList("test_param_value"));
         SavedReportConfiguration basicReport = new SavedReportConfiguration();
         basicReport.setCreatedUser("test_user");
         basicReport.setId("test_report");
         basicReport.setLastModifiedUser("test_user");
-        basicReport.setParameterValues(basicDefaults);
+        basicReport.setParameterValues(basicParams);
         basicReport.setReportName("test_name");
         basicReport.setReportType("test_type");
         SavedReportConfiguration newReport = new SavedReportConfiguration();
         newReport.setCreatedUser("test_user");
         newReport.setId("test_new_report");
         newReport.setLastModifiedUser("test_user");
-        newReport.setParameterValues(basicDefaults);
+        newReport.setParameterValues(basicParams);
         newReport.setReportName("test_name");
         newReport.setReportType("test_type");
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();
@@ -385,20 +388,22 @@ public class ReportConfigsServiceTest {
 
     @Test
     public void saveReportNotExistTest() throws Exception {
-        HashMap<String, String> basicDefaults = new HashMap<>();
+    	HashMap<String, String> basicDefaults = new HashMap<>();
+        HashMap<String, List<String>> basicParams = new HashMap<>();
         basicDefaults.put("test_key", "test_value");
+        basicParams.put("test_param", Arrays.asList("test_param_value"));
         SavedReportConfiguration basicReport = new SavedReportConfiguration();
         basicReport.setCreatedUser("test_user");
         basicReport.setId("test_report");
         basicReport.setLastModifiedUser("test_user");
-        basicReport.setParameterValues(basicDefaults);
+        basicReport.setParameterValues(basicParams);
         basicReport.setReportName("test_name");
         basicReport.setReportType("test_type");
         SavedReportConfiguration newReport = new SavedReportConfiguration();
         newReport.setCreatedUser("test_user");
         newReport.setId("test_new_report");
         newReport.setLastModifiedUser("test_user");
-        newReport.setParameterValues(basicDefaults);
+        newReport.setParameterValues(basicParams);
         newReport.setReportName("test_name");
         newReport.setReportType("test_type");
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();
@@ -459,13 +464,15 @@ public class ReportConfigsServiceTest {
 
     @Test
     public void saveReportAlreadyExistsTest() throws Exception {
-        HashMap<String, String> basicDefaults = new HashMap<>();
+    	HashMap<String, String> basicDefaults = new HashMap<>();
+        HashMap<String, List<String>> basicParams = new HashMap<>();
         basicDefaults.put("test_key", "test_value");
+        basicParams.put("test_param", Arrays.asList("test_param_value"));
         SavedReportConfiguration basicReport = new SavedReportConfiguration();
         basicReport.setCreatedUser("test_user");
         basicReport.setId("test_report");
         basicReport.setLastModifiedUser("test_user");
-        basicReport.setParameterValues(basicDefaults);
+        basicReport.setParameterValues(basicParams);
         basicReport.setReportName("test_name");
         basicReport.setReportType("test_type");
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();
@@ -489,13 +496,15 @@ public class ReportConfigsServiceTest {
 
     @Test
     public void deleteReportBasicTest() throws Exception {
-        HashMap<String, String> basicDefaults = new HashMap<>();
+    	HashMap<String, String> basicDefaults = new HashMap<>();
+        HashMap<String, List<String>> basicParams = new HashMap<>();
         basicDefaults.put("test_key", "test_value");
+        basicParams.put("test_param", Arrays.asList("test_param_value"));
         SavedReportConfiguration basicReport = new SavedReportConfiguration();
         basicReport.setCreatedUser("test_user");
         basicReport.setId("test_report");
         basicReport.setLastModifiedUser("test_user");
-        basicReport.setParameterValues(basicDefaults);
+        basicReport.setParameterValues(basicParams);
         basicReport.setReportName("test_name");
         basicReport.setReportType("test_type");
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();
@@ -513,13 +522,15 @@ public class ReportConfigsServiceTest {
 
     @Test
     public void deleteReportNotExistTest() throws Exception {
-        HashMap<String, String> basicDefaults = new HashMap<>();
+    	HashMap<String, String> basicDefaults = new HashMap<>();
+        HashMap<String, List<String>> basicParams = new HashMap<>();
         basicDefaults.put("test_key", "test_value");
+        basicParams.put("test_param", Arrays.asList("test_param_value"));
         SavedReportConfiguration basicReport = new SavedReportConfiguration();
         basicReport.setCreatedUser("test_user");
         basicReport.setId("test_report");
         basicReport.setLastModifiedUser("test_user");
-        basicReport.setParameterValues(basicDefaults);
+        basicReport.setParameterValues(basicParams);
         basicReport.setReportName("test_name");
         basicReport.setReportType("test_type");
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();


### PR DESCRIPTION
because gw levels can have multiple values, like visit locations, etc.