### PR TITLE
feat: Show error on report save if report type exists

### DIFF
--- a/src/main/java/gov/usgs/aqcu/controller/ConfigController.java
+++ b/src/main/java/gov/usgs/aqcu/controller/ConfigController.java
@@ -1,12 +1,6 @@
 package gov.usgs.aqcu.controller;
 
-import gov.usgs.aqcu.exception.FolderAlreadyExistsException;
-import gov.usgs.aqcu.exception.FolderCannotStoreReportsException;
-import gov.usgs.aqcu.exception.FolderDoesNotExistException;
-import gov.usgs.aqcu.exception.GroupAlreadyExistsException;
-import gov.usgs.aqcu.exception.GroupDoesNotExistException;
-import gov.usgs.aqcu.exception.ReportAlreadyExistsException;
-import gov.usgs.aqcu.exception.ReportDoesNotExistException;
+import gov.usgs.aqcu.exception.*;
 import gov.usgs.aqcu.model.config.FolderData;
 import gov.usgs.aqcu.model.config.GroupData;
 import gov.usgs.aqcu.model.config.persist.FolderProperties;
@@ -155,7 +149,7 @@ public class ConfigController {
 	}
 	
 	// Handle BadRequest Exceptions
-	@ExceptionHandler({GroupAlreadyExistsException.class,FolderAlreadyExistsException.class,ReportAlreadyExistsException.class,FolderCannotStoreReportsException.class})
+	@ExceptionHandler({GroupAlreadyExistsException.class,FolderAlreadyExistsException.class,ReportAlreadyExistsException.class,FolderCannotStoreReportsException.class, ReportTypeAlreadyExistsException.class})
     public void alreadyExistsExceptionHandler(Exception exception, HttpServletResponse response) throws Exception {
         response.sendError(HttpStatus.BAD_REQUEST.value(), exception.getMessage());
 	}

--- a/src/main/java/gov/usgs/aqcu/exception/ReportTypeAlreadyExistsException.java
+++ b/src/main/java/gov/usgs/aqcu/exception/ReportTypeAlreadyExistsException.java
@@ -2,6 +2,6 @@ package gov.usgs.aqcu.exception;
 
 public class ReportTypeAlreadyExistsException extends RuntimeException{
     public ReportTypeAlreadyExistsException(String folder){
-        super(String.format("Specified report type already exist within folder '%1$s'", folder));
+        super(String.format("Specified report type already exists. Please modify the report in folder '%1$s'", folder));
     }
 }

--- a/src/main/java/gov/usgs/aqcu/exception/ReportTypeAlreadyExistsException.java
+++ b/src/main/java/gov/usgs/aqcu/exception/ReportTypeAlreadyExistsException.java
@@ -1,0 +1,7 @@
+package gov.usgs.aqcu.exception;
+
+public class ReportTypeAlreadyExistsException extends RuntimeException{
+    public ReportTypeAlreadyExistsException(String folder){
+        super(String.format("Specified report type already exist within folder '%1$s'", folder));
+    }
+}

--- a/src/main/java/gov/usgs/aqcu/model/config/persist/FolderConfig.java
+++ b/src/main/java/gov/usgs/aqcu/model/config/persist/FolderConfig.java
@@ -2,6 +2,7 @@ package gov.usgs.aqcu.model.config.persist;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 
@@ -54,5 +55,17 @@ public class FolderConfig {
 
 	public Boolean doesReportExist(String id) {
 		return savedReports.containsKey(id);
+	}
+
+	/**
+	 * This method converts the savedReport map from key: id and value: report to  map of key:reportType and value:report
+	 * @return Map of key: reportType and value:report
+	 */
+	public Map<String, SavedReportConfiguration> getSavedReportByType(){
+		return savedReports.values()
+				.stream()
+				.collect(
+						Collectors.toMap(savedReport -> savedReport.getReportType(), savedReport -> savedReport)
+				);
 	}
 }

--- a/src/main/java/gov/usgs/aqcu/reports/ReportConfigsService.java
+++ b/src/main/java/gov/usgs/aqcu/reports/ReportConfigsService.java
@@ -231,7 +231,7 @@ public class ReportConfigsService {
 			throw new FolderCannotStoreReportsException(groupName, folderPath);
 		}
 
-		if(doesReportTypeExists(folderConfig, newReport)){
+		if(!update && doesReportTypeExists(folderConfig, newReport)){
 			throw new ReportTypeAlreadyExistsException(folderPath);
 		}
 		Boolean reportExists = folderConfig.doesReportExist(newReport.getId());

--- a/src/main/java/gov/usgs/aqcu/reports/ReportConfigsService.java
+++ b/src/main/java/gov/usgs/aqcu/reports/ReportConfigsService.java
@@ -6,6 +6,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import com.amazonaws.util.StringUtils;
@@ -13,6 +14,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import gov.usgs.aqcu.exception.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
@@ -229,6 +231,9 @@ public class ReportConfigsService {
 			throw new FolderCannotStoreReportsException(groupName, folderPath);
 		}
 
+		if(doesReportTypeExists(folderConfig, newReport)){
+			throw new ReportTypeAlreadyExistsException(folderPath);
+		}
 		Boolean reportExists = folderConfig.doesReportExist(newReport.getId());
 
 
@@ -272,4 +277,11 @@ public class ReportConfigsService {
 		Path parent = Paths.get(path).getParent();
 		return parent == null ? null : parent.toString();
 	}
+
+	public boolean doesReportTypeExists(FolderConfig folderConfig, SavedReportConfiguration newReport) {
+		Map<String, SavedReportConfiguration> savedReportByType = folderConfig.getSavedReportByType();
+		return savedReportByType.containsKey(newReport.getReportType());
+	}
+
+
 }

--- a/src/test/java/gov/usgs/aqcu/model/config/persist/FolderConfigTest.java
+++ b/src/test/java/gov/usgs/aqcu/model/config/persist/FolderConfigTest.java
@@ -26,5 +26,15 @@ public class FolderConfigTest {
         assertFalse(testConfig.getProperties().getCanStoreReports());
         assertTrue(testConfig.getSavedReports().isEmpty());
     }
+
+    @Test
+    public void WhenReportMapHasValues_getSavedReportByTypeReturnsMapWithKeyReportType(){
+        FolderConfig testConfig = new FolderConfig();
+        SavedReportConfiguration testReport = new SavedReportConfiguration();
+        testReport.setId("123");
+        testReport.setReportType("report_type");
+        testConfig.saveReport(testReport);
+        assertTrue(testConfig.getSavedReportByType().containsKey("report_type"));
+    }
     
 }

--- a/src/test/java/gov/usgs/aqcu/report/ReportConfigsServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/report/ReportConfigsServiceTest.java
@@ -756,7 +756,7 @@ public class ReportConfigsServiceTest {
     public void whenReportTypeExists_thenSaveReportThrowsException() throws IOException {
 
         expectedException.expect(ReportTypeAlreadyExistsException.class);
-        expectedException.expectMessage("already exist within folder 'test_folder'");
+        expectedException.expectMessage("modify the report in folder 'test_folder'");
 
         SavedReportConfiguration report = new SavedReportConfiguration();
         report.setReportType("reportType");

--- a/src/test/java/gov/usgs/aqcu/report/ReportConfigsServiceTest.java
+++ b/src/test/java/gov/usgs/aqcu/report/ReportConfigsServiceTest.java
@@ -2,6 +2,7 @@ package gov.usgs.aqcu.report;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -11,29 +12,28 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.verify;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Collections;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 
+import gov.usgs.aqcu.exception.*;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.junit4.SpringRunner;
 
 import gov.usgs.aqcu.aws.S3Service;
-import gov.usgs.aqcu.exception.FolderAlreadyExistsException;
-import gov.usgs.aqcu.exception.FolderDoesNotExistException;
-import gov.usgs.aqcu.exception.GroupAlreadyExistsException;
-import gov.usgs.aqcu.exception.GroupDoesNotExistException;
-import gov.usgs.aqcu.exception.ReportAlreadyExistsException;
-import gov.usgs.aqcu.exception.ReportDoesNotExistException;
 import gov.usgs.aqcu.model.config.FolderData;
 import gov.usgs.aqcu.model.config.persist.GroupConfig;
 import gov.usgs.aqcu.model.config.GroupData;
@@ -49,12 +49,15 @@ public class ReportConfigsServiceTest {
 
     ReportConfigsService service;
 
+    @Rule
+    public ExpectedException expectedException =  ExpectedException.none();
+
     private final String TEST_GROUP_NAME = "test_group";
     private final String TEST_FOLDER_NAME = "test_folder";
     private final String TEST_SUB_FOLDER_NAME = "test_sub_folder";
     private ObjectMapper mapper = new ObjectMapper().registerModule(new JavaTimeModule())
     .configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
-    
+
     @Before
     public void setup() {
         service = new ReportConfigsService(s3Service);
@@ -446,7 +449,7 @@ public class ReportConfigsServiceTest {
         given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + ReportConfigsService.GROUP_CONFIG_FILE_NAME)).willReturn(true);
         given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(true);
         given(s3Service.getFileAsString(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(mapper.writeValueAsString(basicConfig));
-
+        newReport.setReportType("test_type_2");
         service.saveReport(TEST_GROUP_NAME, TEST_FOLDER_NAME, newReport, false);
 
         // Verify Instant Format
@@ -474,7 +477,7 @@ public class ReportConfigsServiceTest {
         newReport.setId("test_report");
         newReport.setLastModifiedUser("test_user2");
         newReport.setParameterValues(basicParams);
-        newReport.setReportType("test_type");
+        newReport.setReportType("test_type_2");
         newReport.setLastModifiedDate(Instant.parse("2020-02-01T00:00:00Z"));      
         HashMap<String, SavedReportConfiguration> basicReports = new HashMap<>();
         basicReports.put("test_report", basicReport);
@@ -550,6 +553,7 @@ public class ReportConfigsServiceTest {
         given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + ReportConfigsService.GROUP_CONFIG_FILE_NAME)).willReturn(true);
         given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(true);
         given(s3Service.getFileAsString(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(new ObjectMapper().writeValueAsString(basicConfig));
+        newReport.setReportType("test_type_3");
         service.saveReport(TEST_GROUP_NAME, TEST_FOLDER_NAME, newReport, false);
         try {
             service.saveReport(TEST_GROUP_NAME, TEST_FOLDER_NAME, newReport, true);
@@ -596,6 +600,7 @@ public class ReportConfigsServiceTest {
         given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + ReportConfigsService.GROUP_CONFIG_FILE_NAME)).willReturn(true);
         given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(true);
         given(s3Service.getFileAsString(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(new ObjectMapper().writeValueAsString(basicConfig));
+        basicReport.setReportType("test_type_4");
         try {
             service.saveReport(TEST_GROUP_NAME, TEST_FOLDER_NAME, basicReport, false);
             fail("Expected ReportAlreadyExistsException but got no exception.");
@@ -746,6 +751,49 @@ public class ReportConfigsServiceTest {
         result = service.getFolderSubFolders(TEST_GROUP_NAME, "folder_2");
         assertEquals(0, result.size());
     }
+
+    @Test
+    public void whenReportTypeExists_thenSaveReportThrowsException() throws IOException {
+
+        expectedException.expect(ReportTypeAlreadyExistsException.class);
+        expectedException.expectMessage("already exist within folder 'test_folder'");
+
+        SavedReportConfiguration report = new SavedReportConfiguration();
+        report.setReportType("reportType");
+        FolderConfig folderConfig = new FolderConfig();
+        folderConfig.setSavedReports(Collections.singletonMap("id", report));
+
+        given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + ReportConfigsService.GROUP_CONFIG_FILE_NAME)).willReturn(true);
+        given(s3Service.doesFileExist(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(true);
+        given(s3Service.getFileAsString(TEST_GROUP_NAME + "/" + TEST_FOLDER_NAME + "/" + ReportConfigsService.REPORT_CONFIG_FILE_NAME)).willReturn(new ObjectMapper().writeValueAsString(folderConfig));
+
+        service.saveReport(TEST_GROUP_NAME, TEST_FOLDER_NAME, report, false);
+
+    }
+    @Test
+    public void whenReportTypeDoesNotExists_thenDoesReportTypeExistsReturnsFalse(){
+        SavedReportConfiguration basicReport = new SavedReportConfiguration();
+        basicReport.setReportType("reportType");
+
+        SavedReportConfiguration newReport = new SavedReportConfiguration();
+        newReport.setReportType("newReportType");
+
+        FolderConfig folderConfig = new FolderConfig();
+        folderConfig.getSavedReports().put("010101", basicReport );
+
+        assertFalse(service.doesReportTypeExists(folderConfig, newReport));
+    }
+
+    @Test
+    public void whenReportTypeExists_thenDoesReportTypeExistsReturnsTrue(){
+        SavedReportConfiguration basicReport = new SavedReportConfiguration();
+        basicReport.setReportType("reportType");
+
+        FolderConfig folderConfig = new FolderConfig();
+        folderConfig.getSavedReports().put("010101", basicReport );
+        assertTrue(service.doesReportTypeExists(folderConfig, basicReport));
+    }
+
 
     private Boolean jsonEqual(Object ob1, Object ob2) throws Exception {
         ObjectMapper mapper = new ObjectMapper();


### PR DESCRIPTION
This change throw an error message if user try to save a report
 of the same type that exists in the selected folder.

The change was done so we can avoid creation of multiple report
of the same type when mulitple users are working on a folder.

Resolves : AQCU-2053 https://internal.cida.usgs.gov/jira/browse/AQCU-2053